### PR TITLE
Fix text color for dark-theme environment

### DIFF
--- a/content/skin/ssleuth.css
+++ b/content/skin/ssleuth.css
@@ -503,15 +503,19 @@
 }
 .ssleuth-paneltab-domains-item[rank="low"] {
     background: #cbb1b1;
+    color: #000;
 }
 .ssleuth-paneltab-domains-item[rank="medium"] {
     background: #f8eac8;
+    color: #000;
 }
 .ssleuth-paneltab-domains-item[rank="high"] {
     background: #ced7e6;
+    color: #000;
 }
 .ssleuth-paneltab-domains-item[rank="vhigh"] {
     background: #d1e3c4;
+    color: #000;
 }
 
 }


### PR DESCRIPTION
Hi,

If you want to use custom background color, just think to fix text color too.
Because some users can use not standard OS theme (for example dark theme) and so your background with their text color are not readable (too low contrast).

Here is a fix for your domains tab.

Regards,