### PR TITLE
Add support for TLSv1.3

### DIFF
--- a/modules/cipher-suites.js
+++ b/modules/cipher-suites.js
@@ -347,6 +347,11 @@ const tlsVersions = {
         ui: 'TLSv1.2',
         state: 'okay'
     },
+    tlsv1_3: {
+        ui: 'TLSv1.3',
+        state: 'okay'
+    },
+
 
     ff_cache: {
         ui: '<Firefox cache. Reload page>',

--- a/modules/ssleuth.js
+++ b/modules/ssleuth.js
@@ -454,7 +454,7 @@ function setDomainStates(ffStatus, evCert, winId) {
 function setTLSVersion(win, winId) {
     try {
         var index = '';
-        var versionStrings = ['sslv3', 'tlsv1_0', 'tlsv1_1', 'tlsv1_2'];
+        var versionStrings = ['sslv3', 'tlsv1_0', 'tlsv1_1', 'tlsv1_2', 'tlsv1_3'];
 
         // TODO : At the moment, depends on observer module. Change.
         if (Services.vc.compare(Services.appinfo.platformVersion, '36.0') > -1) {


### PR DESCRIPTION
Can be enabled in recent versions of Firefox via `security.tls.version.max = 4`.
You can test it live at https://cloudflare.com/.

Currently SSLeuth shows `<Firefox cache. Reload page>`.